### PR TITLE
Update kube to 0.60 & disable def. features, update k8s-openapi to 0.13

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,9 +10,8 @@ license = "MIT"
 
 [dependencies]
 chrono = "0.4"
-kube = "0.58"
-kube-runtime = "0.58"
-k8s-openapi = { version = "0.12", default-features = false }
+kube = { version = "0.60", default-features = false, features = ["client"] }
+k8s-openapi = { version = "0.13", default-features = false }
 serde = "1"
 serde_json = "1"
 thiserror = "1"
@@ -21,9 +20,8 @@ log = "0.4"
 [dev-dependencies]
 anyhow = "1"
 async-std = { version = "1", features = ["attributes", "tokio1", "tokio02"] }
-kube = "0.58"
-kube-runtime = "0.58"
-k8s-openapi = { version = "0.12", default-features = false, features = ["v1_20"] }
+kube = "0.60"
+k8s-openapi = { version = "0.13", default-features = false, features = ["v1_20"] }
 env_logger = "0.9"
 rand = "0.8"
 cmd_lib = "1"


### PR DESCRIPTION
* Update `kube` to 0.60
* Update `k8s-openapi` to 0.13
* Disable default-features on `kube`, so that crates that depend on this crate are not forced to enable the `native-tls` feature of `kube` (or whatever other default features it may add in future).