### PR TITLE
chore: make justfile work with latest k3d version

### DIFF
--- a/justfile
+++ b/justfile
@@ -9,7 +9,7 @@ start-test-cluster:
   #!/usr/bin/env bash
   set -euo pipefail
   if ! k3d cluster list | grep -qF "{{cluster}}"; then
-    k3d cluster create "{{cluster}}" --k3s-server-arg="--no-deploy=traefik"
+    k3d cluster create "{{cluster}}" --k3s-arg="--disable=traefik@server:0"
   else
     echo "Cluster already running"
   fi


### PR DESCRIPTION
This change-set updates the `k3d` usage in the `justfile` to work with the latest version (5.4 at this time).