### PR TITLE
do not enable chrono default features since that results in a dependency on a vulnerable crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-chrono = "0.4"
+chrono = { version = "0.4", default-features = false }
 kube = { version = "0.75", default-features = false, features = ["client"] }
 k8s-openapi = { version = "0.16.0", default-features = false }
 serde = "1"


### PR DESCRIPTION
Hi!

Unnecessarily enabling the default features on the `chrono` dependency results in the `time` feature being enabled, which currently depends on a crate that has a security vulnerability. Please see https://github.com/chronotope/chrono/issues/602 for the details. It appears we don't need the default features here, so we can let the user decide which `chrono` features they want.

