### PR TITLE
feat!: Update kube to 0.78 and k8s-openapi to 0.17

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,14 +4,13 @@ version = "0.18.0"
 edition = "2018"
 authors = ["Hendrik Maus <aidentailor@gmail.com>"]
 description = "Leader election implementations for Kubernetes workloads"
+repository = "https://github.com/hendrikmaus/kube-leader-election"
 license = "MIT"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 chrono = { version = "0.4", default-features = false }
-kube = { version = "0.77", default-features = false, features = ["client"] }
-k8s-openapi = { version = "0.16.0", default-features = false }
+kube = { version = "0.78", default-features = false, features = ["client"] }
+k8s-openapi = { version = "0.17", default-features = false }
 serde = "1"
 serde_json = "1"
 thiserror = "1"
@@ -21,7 +20,7 @@ log = "0.4"
 anyhow = "1"
 async-std = { version = "1", features = ["attributes", "tokio1", "tokio02"] }
 kube = "0.77"
-k8s-openapi = { version = "0.16.0", default-features = false, features = ["v1_24"] }
+k8s-openapi = { version = "0.17", default-features = false, features = ["v1_24"] }
 env_logger = "0.9"
 rand = "0.8"
 cmd_lib = "1"


### PR DESCRIPTION
I also added the `repository` key to `Cargo.toml` so that docs.rs generates a link back to this GitHub repository, making it easier to find.

I tagged the commit with `Release-As: 0.19.0`

Supersedes #51 