### PR TITLE
Update kube to 0.82 and k8s-openapi to 0.18 (and release as 0.22.0)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,8 @@ license = "MIT"
 
 [dependencies]
 chrono = { version = "0.4", default-features = false }
-kube = { version = "0.80", default-features = false, features = ["client"] }
-k8s-openapi = { version = "0.17", default-features = false }
+kube = { version = "0.82", default-features = false, features = ["client"] }
+k8s-openapi = { version = "0.18", default-features = false }
 serde = "1"
 serde_json = "1"
 thiserror = "1"
@@ -19,8 +19,8 @@ log = "0.4"
 [dev-dependencies]
 anyhow = "1"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
-kube = "0.80"
-k8s-openapi = { version = "0.17", default-features = false, features = ["v1_24"] }
+kube = "0.82"
+k8s-openapi = { version = "0.18", default-features = false, features = ["v1_24"] }
 env_logger = "0.10"
 rand = "0.8"
 cmd_lib = "1"


### PR DESCRIPTION
Release-As: 0.22.0
---
updated-dependencies:
- dependency-name: kube dependency-type: direct:production
- dependency-name: k8s-openapi dependency-type: direct:production