### PR TITLE
feat!: update kube and make k8s-openapi more flexible

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,8 @@ license = "MIT"
 
 [dependencies]
 chrono = { version = "0.4", default-features = false }
-kube = { version = "0.85", default-features = false, features = ["client"] }
-k8s-openapi = { version = "0.19", default-features = false }
+kube = { version = "0.86", default-features = false, features = ["client"] }
+k8s-openapi = { version = "*"}
 serde = "1"
 serde_json = "1"
 thiserror = "1"
@@ -19,8 +19,8 @@ log = "0.4"
 [dev-dependencies]
 anyhow = "1"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
-kube = "0.85"
-k8s-openapi = { version = "0.19", default-features = false, features = ["v1_24"] }
+kube = "0.86"
+k8s-openapi = { version = "*", features = ["v1_24"] }
 env_logger = "0.10"
 rand = "0.8"
 cmd_lib = "1"


### PR DESCRIPTION
- disables default-features for k8s-openapi these have been making it difficult to compile in some situations
- kube updates from 0.85 to 0.86