### PR TITLE
feat!: require k8s-openapi >=0.20

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT"
 [dependencies]
 chrono = { version = "0.4", default-features = false }
 kube = { version = "0.86", default-features = false, features = ["client"] }
-k8s-openapi = { version = "*"}
+k8s-openapi = ">=0.20"
 serde = "1"
 serde_json = "1"
 thiserror = "1"
@@ -20,7 +20,7 @@ log = "0.4"
 anyhow = "1"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 kube = "0.86"
-k8s-openapi = { version = "*", features = ["v1_24"] }
+k8s-openapi = { version = ">=0.20", features = ["v1_28"] }
 env_logger = "0.10"
 rand = "0.8"
 cmd_lib = "1"


### PR DESCRIPTION
The approach taken in https://github.com/hendrikmaus/kube-leader-election/pull/74 is not valid, hence I added `>=0.20` to be more flexible with the dependency.