### PR TITLE
Upgrade kube crate to 3, switch from chrono to jiff

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,9 +8,9 @@ repository = "https://github.com/hendrikmaus/kube-leader-election"
 license = "MIT"
 
 [dependencies]
-chrono = { version = "0.4", default-features = false }
-kube = { version = "2", default-features = false, features = ["client"] }
-k8s-openapi = ">=0.25"
+jiff = { version = "0.2", default-features = false }
+kube = { version = "3", default-features = false, features = ["client"] }
+k8s-openapi = ">=0.27"
 serde = "1"
 serde_json = "1"
 thiserror = "1"
@@ -19,8 +19,8 @@ log = "0.4"
 [dev-dependencies]
 anyhow = "1"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
-kube = "2.0"
-k8s-openapi = { version = ">=0.25", features = ["v1_32"] }
+kube = "3"
+k8s-openapi = { version = ">=0.27", features = ["v1_32"] }
 env_logger = "0.10"
 rand = "0.8"
 cmd_lib = "1"

--- a/src/lease.rs
+++ b/src/lease.rs
@@ -1,7 +1,5 @@
 use k8s_openapi::api::coordination::v1::Lease;
-use k8s_openapi::chrono::SecondsFormat;
 use kube::api::{PatchParams, PostParams};
-use kube::error::ErrorResponse;
 use kube::ResourceExt;
 use serde_json::json;
 
@@ -23,7 +21,7 @@ pub enum Error {
     TraverseLease { key: String },
 
     #[error("got unexpected Kubernetes API error: {response:}")]
-    ApiError { response: ErrorResponse },
+    ApiError { response: Box<kube::error::Status> },
 
     #[error("aborted to release lock because we are not leading, the lock is held by {leader:}")]
     ReleaseLockWhenNotLeading { leader: String },
@@ -36,6 +34,9 @@ pub enum Error {
 
     #[error(transparent)]
     Kube(#[from] kube::Error),
+
+    #[error(transparent)]
+    JiffError(#[from] jiff::Error),
 }
 
 /// Represent a `LeaseLock` mechanism to try and acquire leadership status
@@ -159,7 +160,7 @@ impl LeaseLock {
 
     /// Helper to determine if the given lease has expired and can be acquired
     fn has_lease_expired(&self, lease: &Lease) -> Result<bool, Error> {
-        let now = chrono::Utc::now();
+        let now = jiff::Timestamp::now();
         let spec = lease.spec.as_ref().ok_or(Error::TraverseLease {
             key: "spec".to_string(),
         })?;
@@ -176,22 +177,23 @@ impl LeaseLock {
             .ok_or(Error::TraverseLease {
                 key: "spec.leaseDurationSeconds".to_string(),
             })?;
-        let timeout = last_renewed + chrono::Duration::seconds(*lease_duration as i64);
+        let timeout =
+            last_renewed.checked_add(jiff::SignedDuration::from_secs(*lease_duration as i64))?;
 
         Ok(now.gt(&timeout))
     }
 
     /// Create a `Lease` resource in Kubernetes
     async fn create_lease(&self) -> Result<Lease, Error> {
-        let now: &str = &chrono::Utc::now().to_rfc3339_opts(SecondsFormat::Micros, false);
+        let now = format!("{:.6}", jiff::Timestamp::now());
 
         let lease: Lease = serde_json::from_value(json!({
             "apiVersion": "coordination.k8s.io/v1",
             "kind": "Lease",
             "metadata": { "name": &self.params.lease_name },
             "spec": {
-                "acquireTime": now,
-                "renewTime": now,
+                "acquireTime": now.as_str(),
+                "renewTime": now.as_str(),
                 "holderIdentity": &self.params.holder_id,
                 "leaseDurationSeconds": self.params.lease_ttl.as_secs(),
                 "leaseTransitions": 0
@@ -206,7 +208,7 @@ impl LeaseLock {
 
     /// Acquire the `Lease` resource
     async fn acquire_lease(&self, lease: &Lease) -> Result<Lease, Error> {
-        let now: &str = &chrono::Utc::now().to_rfc3339_opts(SecondsFormat::Micros, false);
+        let now = format!("{:.6}", jiff::Timestamp::now());
         let transitions = &lease
             .spec
             .as_ref()
@@ -223,8 +225,8 @@ impl LeaseLock {
             "kind": "Lease",
             "metadata": { "name": &self.params.lease_name },
             "spec": {
-                "acquireTime": now,
-                "renewTime": now,
+                "acquireTime": now.as_str(),
+                "renewTime": now.as_str(),
                 "leaseTransitions": transitions + 1,
                 "holderIdentity": &self.params.holder_id,
                 "leaseDurationSeconds": self.params.lease_ttl.as_secs(),
@@ -249,7 +251,7 @@ impl LeaseLock {
             "kind": "Lease",
             "metadata": { "name": &self.params.lease_name },
             "spec": {
-                "renewTime": chrono::Utc::now().to_rfc3339_opts(SecondsFormat::Micros, false),
+                "renewTime": format!("{:.6}", jiff::Timestamp::now()),
                 "leaseDurationSeconds": self.params.lease_ttl.as_secs(),
             }
         });
@@ -286,14 +288,14 @@ impl LeaseLock {
             return Err(Error::ReleaseLockWhenNotLeading { leader });
         }
 
-        let now: &str = &chrono::Utc::now().to_rfc3339_opts(SecondsFormat::Micros, false);
+        let now = format!("{:.6}", jiff::Timestamp::now());
         let patch = json!({
             "apiVersion": "coordination.k8s.io/v1",
             "kind": "Lease",
             "metadata": { "name": &self.params.lease_name },
             "spec": {
-                "acquireTime": now,
-                "renewTime": now,
+                "acquireTime": now.as_str(),
+                "renewTime": now.as_str(),
                 "leaseDurationSeconds": 1,
                 "holderIdentity": ""
             }


### PR DESCRIPTION
This upgrades `kube` to version 3, and `k8s-openapi` to >=0.27, thereby fixing #114.

Both crates have replaced `chrono` with `jiff` for datetime handling.

Relevant changelog for `kube`: https://kube.rs/changelog/#300--2026-01-12